### PR TITLE
Fixed script tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,5 +5,5 @@
 <body>
   <p>Page content...</p>
 </body>
-<script type="text/javascript" src="/js/zombie_haiku.js" />
+<script type="text/javascript" src="js/zombie_haiku.js"></script>
 </html>


### PR DESCRIPTION
This lets the zombie haiku generator run successfully in the browser now. I don't really know the specifics of why the first version doesn't work and this version does, but here's a link on SO with more links to resources that can likely explain why.

http://stackoverflow.com/questions/69913/why-dont-self-closing-script-tags-work

Basically, when adding script tags, do this:

```
<script type="text/javascript" src="myfile.js"></script>
```

and **not** this:

```
<script type="text/javascript" src="myfile.js" />
```
